### PR TITLE
fix text.tree.Rd

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,8 @@
 S3method(plot,getTree)
 S3method(plot,reprtree)
 S3method(text,tree)
+export(as.tree)
+export(plot.getTree)
 export(ReprTree)
 import(randomForest)
 import(tree)

--- a/R/functions.R
+++ b/R/functions.R
@@ -2,11 +2,18 @@
 # 
 # This function takes the results of a \code{randomForest::getTree} call and 
 # converts the results to a form compatible with \code{tree}
-# @param gTree The results of a call to \code{getTree}
-# @param rforest The randomForest object 
+#' @param gTree The results of a call to \code{getTree}
+#' @param rforest The randomForest object 
+#' @param caret using caret T or F
 # @return An object of class \code{tree}, which has a \code{frame} and sufficient
 #     attributes to enable plotting
-as.tree <- function(gTree,rforest,max.depth=3){
+as.tree <- function(gTree,rforest,max.depth=3,caret=FALSE){
+
+  if(caret){
+    mod<-rforest
+    rforest<-mod$finalModel
+  }
+
   if(is.numeric(gTree[,'split var'])) stop("labelVar=T required")
   bl <- matrix("", nrow=nrow(gTree), ncol=3)
   for(row in 1:nrow(gTree)){
@@ -28,7 +35,12 @@ as.tree <- function(gTree,rforest,max.depth=3){
   fr$yval <- gTree[,'prediction']
   
   # Need to work out split points based on classes of the splitting vars
-  classes <- attributes(rforest$terms)$dataClasses
+   if(caret){
+    classes <- attr(terms(mod), "dataClasses")
+  } else {
+    classes <- attributes(rforest$terms)$dataClasses
+  }
+  
   blah <- data.frame(var=fr$var, splits=as.character(gTree[,'split point']), 
                 classes=classes[fr$var], stringsAsFactors=F)
   index <- which(blah$classes=='factor' & !is.na(blah$classes))

--- a/R/plot.getTree.R
+++ b/R/plot.getTree.R
@@ -5,18 +5,31 @@
 #' @param k The index of the tree to be plotted
 #' @param depth The depth of the tree to be plotted
 #' @param main The title to put on the graph
+#' @param caret using caret T or F
 #' @param ... Additional parameters to be passed to \code{text.tree}
 #' @export
 #' @examples
 #' library(randomForest)
 #' rforest <- randomForest(Species~., data=iris, ntree=20)
 #' plot.getTree(rforest, k=3, depth=4)
-plot.getTree <- function(rforest=NULL,tr=NULL,k=1, depth=0,main=NULL, ...){
+plot.getTree <- function(rforest=NULL,tr=NULL,k=1, depth=0,main=NULL,caret=F, ...){
   require(randomForest)
+  if(caret){
+    mod<-rforest
+    rforest<-mod$finalModel
+  }
+  
   if(is.null(rforest) && is.null(tr))stop('One of a random forest object or a tree object must be input')
   if(!is.null(rforest)){
     gTree <- getTree(rforest, k=k, labelVar=TRUE)
-    x <- as.tree(gTree, rforest)
+    
+    if(caret){
+      x <- as.tree(gTree, mod, caret=T)
+    }
+    else{
+      x <- as.tree(gTree, rforest)
+    }
+    
   } else {
     x <- tr
   }

--- a/man/text.tree.Rd
+++ b/man/text.tree.Rd
@@ -37,7 +37,5 @@ If the lettering is vertical (par srt = 90) and adj is not supplied it is adjust
 \author{
 Abhijit Dasgupta, modifying original code by B.D. Ripley
 }
-\seealso{
-\link{\code{plot.tree}}
-}
+
 


### PR DESCRIPTION
fix bug in text.tree.Rd

 text.tree                               html  
Error:***/Temp/RtmpisYKkm/R.INSTALL33ac3c854c63/reprtree/man/text.tree.Rd:41: Bad \link text
* removing 'C:/usr/local/lib/R/site-library/reprtree'